### PR TITLE
iMX8M: enable Enet controller on iMX8M Mini

### DIFF
--- a/NXP/MCIMX8M_MINI_EVK_2GB/AcpiTables/Dsdt.asl
+++ b/NXP/MCIMX8M_MINI_EVK_2GB/AcpiTables/Dsdt.asl
@@ -28,5 +28,6 @@ DefinitionBlock("DsdtTable.aml", "DSDT", 5, "MSFT", "EDK2", 1) {
     include("Dsdt-Gpio.asl")
     include("Dsdt-Spi.asl")
     include("Dsdt-Rhp.asl")
+    include("Dsdt-Enet.asl")
   }
 }


### PR DESCRIPTION
- add Dsdt-Enet to ACPI table for iMX8M Mini