### PR TITLE
IMX8M: disable USB2 port for NXP iMX8M Mini EVK

### DIFF
--- a/NXP/MCIMX8M_MINI_EVK_2GB/AcpiTables/Dsdt-Usb.asl
+++ b/NXP/MCIMX8M_MINI_EVK_2GB/AcpiTables/Dsdt-Usb.asl
@@ -70,7 +70,7 @@ Device (USB2)
   Name (_S0W, 0x0)
 
   Method (_STA) {
-    Return (0xf)
+    Return (0x0)
   }
 
   Name (_CRS, ResourceTemplate () {


### PR DESCRIPTION
  Disable OS use of the USB2 port in ACPI for the iMX8M Mini.  The 4.14.98_2.0.0_GA U-Boot doesn't
  leave it in a usable state when no devices are connected and used as the board power supply.