### PR TITLE
IMX8: Fix build break for iMX8M Mini devices

### DIFF
--- a/NXP/MCIMX8M_MINI_EVK_2GB/MCIMX8M_MINI_EVK_2GB.dsc
+++ b/NXP/MCIMX8M_MINI_EVK_2GB/MCIMX8M_MINI_EVK_2GB.dsc
@@ -42,10 +42,11 @@
 #
 ################################################################################
 
-!include iMX8Pkg/iMX8ConfigDsc.inc
-
 # Include common peripherals
-!include Silicon/ARM/NXP/iMX8Pkg/iMX8CommonDsc.inc
+!include iMX8Pkg/iMX8CommonDsc.inc
+!if $(CONFIG_FRONTPAGE) == TRUE
+!include FrontpageDsc.inc
+!endif
 
 ################################################################################
 #


### PR DESCRIPTION
Build changes for iMX8M weren't propagated to iMX8M Mini