### PR TITLE
iMX8: Enable UART1 on iMX8MQ EVK

### DIFF
--- a/NXP/MCIMX8M_EVK_4GB/AcpiTables/Dsdt-Uart.asl
+++ b/NXP/MCIMX8M_EVK_4GB/AcpiTables/Dsdt-Uart.asl
@@ -1,0 +1,55 @@
+/** @file
+*
+* Description: iMX8M Quad UART
+*
+*  Copyright (c) 2019, Microsoft Corporation. All rights reserved.
+*
+*  This program and the accompanying materials
+*  are licensed and made available under the terms and conditions of the BSD License
+*  which accompanies this distribution.  The full text of the license may be found at
+*  http://opensource.org/licenses/bsd-license.php
+*
+*  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+*
+**/
+
+Device (UAR1)
+{
+    Name (_HID, "NXP0113") //NXP0113 for 24MHz UART_CLK_ROOT
+    Name (_UID, 0x1)
+    Name (_DDN, "UART1")
+    Method (_STA)
+    {
+       Return(0xF)
+    }
+    Method (_CRS, 0x0, NotSerialized) {
+        Name (RBUF, ResourceTemplate () {
+            MEMORY32FIXED(ReadWrite, 0x30860000, 0x4000, )
+            Interrupt(ResourceConsumer, Level, ActiveHigh, Exclusive) { 58 }
+
+            UARTSerialBus (
+            115200,
+            DataBitsEight,
+            StopBitsOne,
+            0,                // LinesInUse
+            LittleEndian,
+            ParityTypeNone,
+            FlowControlNone,
+            0,
+            0,
+            "\\_SB.CPU0",
+            0,
+            ResourceConsumer,
+            ,)
+        })
+        Return(RBUF)
+    }
+
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
+}

--- a/NXP/MCIMX8M_EVK_4GB/MCIMX8M_EVK_4GB.dsc
+++ b/NXP/MCIMX8M_EVK_4GB/MCIMX8M_EVK_4GB.dsc
@@ -120,6 +120,9 @@
   ## iMXPlatformPackage - Serial Terminal
   giMXPlatformTokenSpaceGuid.PcdSerialRegisterBase|0x30860000
 
+  ## iMXPlatformPackage - Debug UART instance UART1 0x30860000
+  giMXPlatformTokenSpaceGuid.PcdKdUartInstance|1
+
   # uSDHCx | iMX8M EVK Connections
   #-------------------------------------
   # uSDHC1 | eMMC


### PR DESCRIPTION
- note: conflicts with kernel debugger serial port.  To enable UART, disable kernel debugger in BCD.